### PR TITLE
Fill forecast cards with aggregated OpenMeteo metrics

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -1,6 +1,188 @@
 # helper_functions.py
+import re
 import pandas as pd
 import numpy as np
+
+
+def _series_mean(series: pd.Series | None) -> float | None:
+    if series is None:
+        return None
+    numeric = pd.to_numeric(series, errors="coerce").dropna()
+    if numeric.empty:
+        return None
+    return float(numeric.mean())
+
+
+def _circular_mean_deg(series: pd.Series | None) -> float | None:
+    if series is None:
+        return None
+    numeric = pd.to_numeric(series, errors="coerce").dropna()
+    if numeric.empty:
+        return None
+    radians = np.deg2rad(numeric % 360)
+    sin_mean = np.sin(radians).mean()
+    cos_mean = np.cos(radians).mean()
+    if np.isclose([sin_mean, cos_mean], 0).all():
+        return None
+    angle = np.rad2deg(np.arctan2(sin_mean, cos_mean))
+    if angle < 0:
+        angle += 360
+    return float(angle)
+
+
+def _ms_to_beaufort(ms: float | None) -> int | None:
+    if ms is None or pd.isna(ms):
+        return None
+    thresholds = [
+        0.5,
+        1.5,
+        3.3,
+        5.5,
+        7.9,
+        10.7,
+        13.8,
+        17.1,
+        20.7,
+        24.4,
+        28.4,
+        32.6,
+    ]
+    for idx, limit in enumerate(thresholds):
+        if ms < limit:
+            return idx
+    return 12
+
+
+def _deg_to_compass(deg: float | None) -> str | None:
+    if deg is None or pd.isna(deg):
+        return None
+    directions = [
+        "N",
+        "NNO",
+        "NO",
+        "ONO",
+        "O",
+        "OZO",
+        "ZO",
+        "ZZO",
+        "Z",
+        "ZZW",
+        "ZW",
+        "WZW",
+        "W",
+        "WNW",
+        "NW",
+        "NNW",
+    ]
+    idx = int(((deg % 360) / 22.5) + 0.5) % len(directions)
+    return directions[idx]
+
+
+def _hour_to_daypart(hour: float | int | None) -> str | None:
+    if hour is None or pd.isna(hour):
+        return None
+    if hour < 12:
+        return "ochtend"
+    if hour < 18:
+        return "middag"
+    if hour < 24:
+        return "avond"
+    return None
+
+
+_LOCATION_ALIASES = {
+    "wijkenzeenoordpier": "wijk aan zee",
+    "wijkaanzeenoordpier": "wijk aan zee",
+    "wijkenzee": "wijk aan zee",
+    "wijkaanzee": "wijk aan zee",
+    "scheveningen": "scheveningen",
+}
+
+
+def _canonicalize_location(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    cleaned = re.sub(r"[^a-z0-9]", "", text.lower())
+    if cleaned in _LOCATION_ALIASES:
+        return _LOCATION_ALIASES[cleaned]
+    # fallback: replace separators with spaces for readability
+    return re.sub(r"[_-]+", " ", text).strip().lower() or None
+
+
+def aggregate_openmeteo_dayparts(
+    dfs: dict[str, pd.DataFrame],
+    tz: str = "Europe/Amsterdam",
+) -> dict[str, list[dict]]:
+    """Aggregate hourly OpenMeteo data into dayparts per spot/day."""
+
+    results: dict[str, list[dict]] = {}
+
+    for location, df in dfs.items():
+        df_local = df.copy()
+        df_local["date"] = pd.to_datetime(df_local["date"], utc=True, errors="coerce")
+        df_local = df_local.dropna(subset=["date"])
+        if df_local.empty:
+            continue
+
+        df_local["date_local"] = df_local["date"].dt.tz_convert(tz)
+        df_local["date_str"] = df_local["date_local"].dt.strftime("%Y-%m-%d")
+        df_local["hour"] = df_local["date_local"].dt.hour
+        df_local["daypart"] = df_local["hour"].apply(_hour_to_daypart)
+        df_local = df_local.dropna(subset=["date_str", "daypart"])
+        if df_local.empty:
+            continue
+
+        per_date: dict[str, dict] = {}
+        grouped = df_local.groupby(["date_str", "daypart"], dropna=True)
+
+        for (date, part), group in grouped:
+            wave_height = _series_mean(group.get("wave_height"))
+            swell_period = _series_mean(group.get("swell_wave_period"))
+            wind_speed = _series_mean(group.get("wind_speed_10m"))
+            wind_dir_deg = _circular_mean_deg(group.get("wind_direction_10m"))
+
+            if all(
+                value is None
+                for value in (wave_height, swell_period, wind_speed, wind_dir_deg)
+            ):
+                continue
+
+            entry = {
+                "swell_m": round(wave_height, 1) if wave_height is not None else None,
+                "period_s": int(round(swell_period)) if swell_period is not None else None,
+                "wind_bft": _ms_to_beaufort(wind_speed),
+                "wind_kmh": round(wind_speed * 3.6) if wind_speed is not None else None,
+                "wind_dir": _deg_to_compass(wind_dir_deg),
+                "wind_dir_deg": int(round(wind_dir_deg)) if wind_dir_deg is not None else None,
+                "source": "openmeteo",
+            }
+
+            if all(
+                entry.get(field) in (None, "")
+                for field in ("swell_m", "period_s", "wind_bft", "wind_dir", "wind_kmh")
+            ):
+                continue
+
+            parts = per_date.setdefault(date, {})
+            parts[part] = entry
+
+        if not per_date:
+            continue
+
+        spot_id = _canonicalize_location(location)
+        if not spot_id:
+            continue
+
+        day_entries = [
+            {"date": date, "parts": parts, "source": "openmeteo"}
+            for date, parts in sorted(per_date.items())
+        ]
+
+        results[spot_id] = day_entries
+
+    return results
+
 
 def to_json_array(dfs: dict[str, pd.DataFrame], tz, dutch_days, field_order):
     out = []

--- a/openmeteo_api.py
+++ b/openmeteo_api.py
@@ -1,9 +1,8 @@
-import json
 import pandas as pd
 import requests_cache
 from retry_requests import retry
 import openmeteo_requests
-from helper_functions import to_json_array
+from helper_functions import aggregate_openmeteo_dayparts
 
 # === Open-meteo =====================================================
 
@@ -19,8 +18,26 @@ def get_openmeteo_data():
     params = {
         "latitude": [52.4693, 52.1066],
         "longitude": [4.556, 4.2654],
-        "hourly": ["wave_height", "wave_direction", "wave_period", "wind_wave_peak_period", "wind_wave_height", "wind_wave_direction", "wind_wave_period", "swell_wave_height", "swell_wave_period", "swell_wave_direction", "swell_wave_peak_period", "secondary_swell_wave_height", "secondary_swell_wave_period", "secondary_swell_wave_direction", "sea_surface_temperature"],
-        "forecast_days": 3
+        "hourly": [
+            "wave_height",
+            "wave_direction",
+            "wave_period",
+            "wind_wave_peak_period",
+            "wind_wave_height",
+            "wind_wave_direction",
+            "wind_wave_period",
+            "swell_wave_height",
+            "swell_wave_period",
+            "swell_wave_direction",
+            "swell_wave_peak_period",
+            "secondary_swell_wave_height",
+            "secondary_swell_wave_period",
+            "secondary_swell_wave_direction",
+            "sea_surface_temperature",
+            "wind_speed_10m",
+            "wind_direction_10m",
+        ],
+        "forecast_days": 3,
     }
     responses = openmeteo.weather_api(url, params=params)
 
@@ -49,6 +66,8 @@ def get_openmeteo_data():
         hourly_secondary_swell_wave_period = hourly.Variables(12).ValuesAsNumpy()
         hourly_secondary_swell_wave_direction = hourly.Variables(13).ValuesAsNumpy()
         hourly_sea_surface_temperature = hourly.Variables(14).ValuesAsNumpy()
+        hourly_wind_speed_10m = hourly.Variables(15).ValuesAsNumpy()
+        hourly_wind_direction_10m = hourly.Variables(16).ValuesAsNumpy()
         
         hourly_data = {"date": pd.date_range(
             start = pd.to_datetime(hourly.Time(), unit = "s", utc = True),
@@ -72,33 +91,15 @@ def get_openmeteo_data():
         hourly_data["secondary_swell_wave_period"] = hourly_secondary_swell_wave_period
         hourly_data["secondary_swell_wave_direction"] = hourly_secondary_swell_wave_direction
         hourly_data["sea_surface_temperature"] = hourly_sea_surface_temperature
+        hourly_data["wind_speed_10m"] = hourly_wind_speed_10m
+        hourly_data["wind_direction_10m"] = hourly_wind_direction_10m
         
         hourly_dataframe = pd.DataFrame(data = hourly_data)
         dfs[location] = hourly_dataframe
 
-    # aannames:
-    # - dfs: dict[str -> pd.DataFrame] met kolom 'date' (tz-aware of UTC epoch naar dt al gedaan)
-    # - alle overige kolommen zoals in je voorbeeld aanwezig
+    aggregated = aggregate_openmeteo_dayparts(dfs)
 
-    tz = "Europe/Amsterdam"
-    dutch_days = ["Maandag","Dinsdag","Woensdag","Donderdag","Vrijdag","Zaterdag","Zondag"]
-
-    # Exacte doeldvolgorde (en labels) zoals jij vroeg
-    field_order = [
-        "Datum", "Dag", "Locatie", "Tijd",
-        "wave_height", "wave_direction", "wave_period",
-        "wind_wave_peak_period", "wind_wave_height", "wind_wave_direction", "wind_wave_period",
-        "swell_wave_height", "swell_wave_period", "swell_wave_direction", "swell_wave_peak_period",
-        "secondary_swell_wave_height", "secondary_swell_wave_period", "secondary_swell_wave_direction",
-        "sea_surface_temperature",
-    ]
-
-    json_output = to_json_array(dfs, tz, dutch_days, field_order)
-
-    return json_output  # is nu een list, geen string
-
-
-    return json_output
+    return aggregated
 
 
 

--- a/react-app.js
+++ b/react-app.js
@@ -7,6 +7,10 @@ const RPC_NAME = "get_latest_sms_public";
 
 const { useState, useEffect } = window.React;
 
+function normalizeSpotId(id){
+  return String(id || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
 /* ===== Spot metadata ===== */
 const SPOTS_META = {
   "scheveningen": { name: "Scheveningen", region: "Z-H", shoreBearing: 260 },
@@ -38,13 +42,167 @@ const SPOTS_META = {
   "de panne": { name: "De Panne", region: "BE", shoreBearing: 230 },
   "ter heijde": { name: "Ter Heijde", region: "Z-H", shoreBearing: 260 }
 };
+const SPOT_ALIAS_MAP = (() => {
+  const map = new Map();
+  Object.keys(SPOTS_META).forEach(key => {
+    const norm = normalizeSpotId(key);
+    if (norm && !map.has(norm)) map.set(norm, key);
+  });
+  return map;
+})();
+const OPENMETEO_ALIASES = new Map([
+  ['wijkaanzeenoordpier', 'wijk aan zee'],
+  ['wijkenzeenoordpier', 'wijk aan zee'],
+  ['wijkaanzee', 'wijk aan zee'],
+  ['scheveningen', 'scheveningen']
+]);
 const DEFAULT_META = { name: null, region: null, shoreBearing: 260 };
 const getSpotMeta = (id) =>
   SPOTS_META[String(id || "").toLowerCase()] || { name: id, ...DEFAULT_META };
 
 const PART_KEYS = ["ochtend", "middag", "avond"];
 const PART_LABELS = { ochtend: "Ochtend", middag: "Middag", avond: "Avond" };
-const DEFAULT_PART_VALUES = { swell_m: 0, period_s: 0, wind_bft: 0, wind_dir: null };
+
+function safeNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function parseJSONSafe(value) {
+  if (value == null) return null;
+  if (typeof value === 'object') return value;
+  if (typeof value === 'string') {
+    try { return JSON.parse(value); } catch (err) { console.warn('Kon JSON niet parsen', err); }
+  }
+  return null;
+}
+
+function average(values){
+  if (!values || !values.length) return null;
+  const sum = values.reduce((acc, val) => acc + val, 0);
+  return sum / values.length;
+}
+
+function meanCircularDeg(values){
+  if (!values || !values.length) return null;
+  const radians = values.map(v => (v * Math.PI) / 180);
+  const sin = radians.reduce((acc, rad) => acc + Math.sin(rad), 0) / values.length;
+  const cos = radians.reduce((acc, rad) => acc + Math.cos(rad), 0) / values.length;
+  if (!Number.isFinite(sin) || !Number.isFinite(cos)) return null;
+  const angle = Math.atan2(sin, cos) * (180 / Math.PI);
+  return angle < 0 ? angle + 360 : angle;
+}
+
+function msToBeaufort(ms){
+  if (ms == null || !Number.isFinite(ms)) return null;
+  const limits = [0.5,1.5,3.3,5.5,7.9,10.7,13.8,17.1,20.7,24.4,28.4,32.6];
+  for (let i = 0; i < limits.length; i += 1){
+    if (ms < limits[i]) return i;
+  }
+  return 12;
+}
+
+function degToCompass(deg){
+  if (deg == null || !Number.isFinite(deg)) return null;
+  const dirs = ['N','NNO','NO','ONO','O','OZO','ZO','ZZO','Z','ZZW','ZW','WZW','W','WNW','NW','NNW'];
+  const idx = Math.round(((deg % 360) / 22.5)) % dirs.length;
+  return dirs[idx];
+}
+
+function hourToDaypart(hour){
+  if (!Number.isFinite(hour)) return null;
+  if (hour < 12) return 'ochtend';
+  if (hour < 18) return 'middag';
+  if (hour < 24) return 'avond';
+  return null;
+}
+
+function aggregateOpenMeteoArray(records){
+  if (!Array.isArray(records)) return {};
+  const buckets = new Map();
+  const originalNames = new Map();
+
+  records.forEach(rec => {
+    const spotRaw = rec?.Locatie ?? rec?.locatie ?? rec?.location;
+    const date = rec?.Datum ?? rec?.datum ?? rec?.date;
+    const time = rec?.Tijd ?? rec?.tijd ?? rec?.time;
+    if (!spotRaw || !date || !time) return;
+    const hour = Number(String(time).split(':')[0]);
+    const part = hourToDaypart(hour);
+    if (!part) return;
+    const normSpot = normalizeSpotId(spotRaw);
+    if (!normSpot) return;
+    const spotEntry = buckets.get(normSpot) || new Map();
+    if (!buckets.has(normSpot)) buckets.set(normSpot, spotEntry);
+    if (!originalNames.has(normSpot)) originalNames.set(normSpot, spotRaw);
+    const dayEntry = spotEntry.get(date) || { date, parts: {} };
+    if (!spotEntry.has(date)) spotEntry.set(date, dayEntry);
+    const partBucket = dayEntry.parts[part] || (dayEntry.parts[part] = {
+      wave: [],
+      period: [],
+      windSpeed: [],
+      windDir: []
+    });
+
+    const waveHeight = safeNumber(rec.wave_height ?? rec.swell_wave_height);
+    if (waveHeight != null) partBucket.wave.push(waveHeight);
+    const swellPeriod = safeNumber(rec.swell_wave_period ?? rec.wave_period);
+    if (swellPeriod != null) partBucket.period.push(swellPeriod);
+    const windSpeed = safeNumber(rec.wind_speed_10m ?? rec.wind_speed);
+    if (windSpeed != null) partBucket.windSpeed.push(windSpeed);
+    const windDir = safeNumber(rec.wind_direction_10m ?? rec.wind_wave_direction);
+    if (windDir != null) partBucket.windDir.push(windDir);
+  });
+
+  const result = {};
+  buckets.forEach((datesMap, normSpot) => {
+    const canonical = OPENMETEO_ALIASES.get(normSpot)
+      || SPOT_ALIAS_MAP.get(normSpot)
+      || originalNames.get(normSpot)
+      || normSpot;
+    const days = [];
+    datesMap.forEach(day => {
+      const parts = {};
+      Object.entries(day.parts).forEach(([partKey, values]) => {
+        const entry = {};
+        if (values.wave.length){
+          const avgWave = average(values.wave);
+          if (avgWave != null) entry.swell_m = Number(avgWave.toFixed(1));
+        }
+        if (values.period.length){
+          const avgPeriod = average(values.period);
+          if (avgPeriod != null) entry.period_s = Math.round(avgPeriod);
+        }
+        if (values.windSpeed.length){
+          const avgWind = average(values.windSpeed);
+          if (avgWind != null){
+            entry.wind_bft = msToBeaufort(avgWind);
+            entry.wind_kmh = Math.round(avgWind * 3.6);
+          }
+        }
+        const meanDir = meanCircularDeg(values.windDir);
+        if (meanDir != null){
+          entry.wind_dir_deg = Math.round(meanDir);
+          entry.wind_dir = degToCompass(meanDir);
+        }
+        if (['swell_m','period_s','wind_bft','wind_kmh','wind_dir'].some(k => entry[k] != null)){
+          entry.source = 'openmeteo';
+          parts[partKey] = entry;
+        }
+      });
+      if (Object.keys(parts).length){
+        days.push({ date: day.date, parts, source: 'openmeteo' });
+      }
+    });
+    if (days.length){
+      days.sort((a,b) => (a.date || '').localeCompare(b.date || ''));
+      result[canonical] = days;
+    }
+  });
+
+  return result;
+}
+
 
 /* ===== Utils ===== */
 function degDiff(a, b) { let d = Math.abs(a - b) % 360; if (d > 180) d = 360 - d; return d; }
@@ -71,7 +229,7 @@ function parseWindDirString(dir){
 }
 function computeWindType(spotMeta, windDirStr){
   const deg = parseWindDirString(windDirStr);
-  if (deg === null) return 'unknown';
+  if (deg === null) return null;
   const diff = degDiff(deg, spotMeta.shoreBearing ?? 260);
   if (diff <= 45) return 'onshore';
   if (Math.abs(diff - 180) <= 45) return 'offshore';
@@ -107,10 +265,78 @@ async function loadFromSupabase(){
   const { data, error } = await supa.rpc(RPC_NAME);
   if (error) throw error;
   const row = Array.isArray(data) && data.length ? data[0] : null;
-  if (!row || row.body_processed == null) return {};
-  const payload = (typeof row.body_processed === "string") ? JSON.parse(row.body_processed) : row.body_processed;
-  Object.keys(payload).forEach(k => payload[k].sort((a,b) => (a.date||"").localeCompare(b.date||"")));
-  return payload;
+  if (!row) return {};
+
+  const payload = parseJSONSafe(row.body_processed) || {};
+  Object.keys(payload).forEach(k => {
+    if (Array.isArray(payload[k])) {
+      payload[k].sort((a,b) => (a?.date||"").localeCompare(b?.date||""));
+    }
+  });
+
+  const meteoRaw = parseJSONSafe(row.openmeteo);
+  let meteoAgg = {};
+  if (Array.isArray(meteoRaw)) {
+    meteoAgg = aggregateOpenMeteoArray(meteoRaw);
+  } else if (meteoRaw && typeof meteoRaw === 'object') {
+    meteoAgg = meteoRaw;
+  }
+  const merged = { ...payload };
+  const lookup = new Map();
+  Object.keys(merged).forEach(key => {
+    const norm = normalizeSpotId(key);
+    if (norm && !lookup.has(norm)) lookup.set(norm, key);
+  });
+
+  Object.entries(meteoAgg).forEach(([spotIdRaw, days]) => {
+    const normId = normalizeSpotId(spotIdRaw);
+    const targetKey = lookup.get(normId) || spotIdRaw;
+    if (!lookup.has(normId)) lookup.set(normId, targetKey);
+
+    const existing = Array.isArray(merged[targetKey]) ? [...merged[targetKey]] : [];
+    const indexByDate = new Map(existing.map((entry, idx) => [entry?.date, { idx, value: entry }]));
+
+    (Array.isArray(days) ? days : []).forEach(day => {
+      if (!day || !day.date) return;
+      const partEntries = day.parts && typeof day.parts === 'object' ? day.parts : {};
+      const normalizedParts = {};
+      Object.entries(partEntries).forEach(([partKey, values]) => {
+        if (!partKey) return;
+        const cleanKey = partKey.toLowerCase();
+        normalizedParts[cleanKey] = {
+          ...(typeof values === 'object' && values ? values : {}),
+          source: 'openmeteo'
+        };
+      });
+
+      const existingRef = indexByDate.get(day.date);
+      if (existingRef) {
+        const current = existingRef.value || {};
+        const mergedParts = { ...(current.parts || {}) };
+        Object.entries(normalizedParts).forEach(([partKey, partValues]) => {
+          mergedParts[partKey] = { ...(current.parts?.[partKey] || {}), ...partValues };
+        });
+        const updated = {
+          ...current,
+          parts: mergedParts,
+          date: current.date || day.date,
+          source: current.source || day.source || 'openmeteo'
+        };
+        existing[existingRef.idx] = updated;
+      } else {
+        existing.push({
+          date: day.date,
+          parts: normalizedParts,
+          source: day.source || 'openmeteo'
+        });
+      }
+    });
+
+    existing.sort((a,b) => (a?.date||"").localeCompare(b?.date||""));
+    merged[targetKey] = existing;
+  });
+
+  return merged;
 }
 
 /* ===== Sidebar ===== */
@@ -298,13 +524,20 @@ function HomePage() {
 
   function computeDayAgg(spotId, dayEntry){
     const meta = getSpotMeta(spotId);
-    const partsArr = PART_KEYS.map(k =>
-      (dayEntry.parts && dayEntry.parts[k]) ? dayEntry.parts[k] : DEFAULT_PART_VALUES
-    );
-    const swell_avg = partsArr.reduce((a,p) => a + (p.swell_m||0), 0) / partsArr.length;
-    const period_avg = Math.round(partsArr.reduce((a,p) => a + (p.period_s||0), 0) / partsArr.length);
-    const wind_bft_avg = Math.round(partsArr.reduce((a,p) => a + (p.wind_bft||0), 0) / partsArr.length);
-    const wind_dir = partsArr[1]?.wind_dir || partsArr[0]?.wind_dir || partsArr[2]?.wind_dir || null;
+    const partsByKey = PART_KEYS.map(k => (dayEntry.parts && dayEntry.parts[k]) ? dayEntry.parts[k] : null);
+    const validParts = partsByKey.filter(Boolean);
+    const swellValues = validParts.map(p => safeNumber(p.swell_m)).filter(v => v != null);
+    const periodValues = validParts.map(p => safeNumber(p.period_s)).filter(v => v != null);
+    const windValues = validParts.map(p => safeNumber(p.wind_bft)).filter(v => v != null);
+
+    const swell_avg = swellValues.length ? swellValues.reduce((a, b) => a + b, 0) / swellValues.length : 0;
+    const period_avg = periodValues.length ? Math.round(periodValues.reduce((a, b) => a + b, 0) / periodValues.length) : 0;
+    const wind_bft_avg = windValues.length ? Math.round(windValues.reduce((a, b) => a + b, 0) / windValues.length) : null;
+    const wind_dir =
+      dayEntry.parts?.["middag"]?.wind_dir ||
+      dayEntry.parts?.["ochtend"]?.wind_dir ||
+      dayEntry.parts?.["avond"]?.wind_dir ||
+      null;
     const wind_type = computeWindType(meta, wind_dir);
     const score = computeScore({ swell_m: swell_avg, period_s: period_avg, wind_bft: wind_bft_avg, wind_type });
     return {
@@ -313,9 +546,9 @@ function HomePage() {
       alert: !!dayEntry.alert,
       swell_m: isFinite(swell_avg) ? +swell_avg.toFixed(2) : null,
       period_s: isFinite(period_avg) ? period_avg : null,
-      wind_bft: isFinite(wind_bft_avg) ? wind_bft_avg : null,
-      wind_dir,
-      wind_type,
+      wind_bft: Number.isFinite(wind_bft_avg) ? wind_bft_avg : null,
+      wind_dir: wind_dir || null,
+      wind_type: wind_type || null,
       score,
       summary: buildConclusion({ score }),
       sms: dummySms

--- a/supabase_api.py
+++ b/supabase_api.py
@@ -10,6 +10,7 @@ SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY")
 SUPABASE_EMAIL = os.getenv("SUPABASE_EMAIL")
 SUPABASE_PASSWORD = os.getenv("SUPABASE_PASSWORD")
 
+
 # === Auth: access token ophalen (machine user) =====================
 def get_access_token():
     url = f"{SUPABASE_URL}/auth/v1/token?grant_type=password"
@@ -21,6 +22,7 @@ def get_access_token():
     r = requests.post(url, headers=headers, json=payload, timeout=30)
     r.raise_for_status()
     return r.json()["access_token"]
+
 
 # === RPC wrappers ===================================================
 def rpc_get_unprocessed(limit=10, access_token=None):
@@ -34,6 +36,7 @@ def rpc_get_unprocessed(limit=10, access_token=None):
     r = requests.post(url, headers=headers, json=payload, timeout=30)
     r.raise_for_status()
     return r.json()  # [{id, body}, ...]
+
 
 def rpc_set_body_processed(row_id, value, access_token=None, as_text=False):
     fn = "set_body_processed_text" if as_text else "set_body_processed"
@@ -49,6 +52,7 @@ def rpc_set_body_processed(row_id, value, access_token=None, as_text=False):
     r.raise_for_status()
     # RPC returns no body (void)
     return True
+
 
 def rpc_set_openmeteo(row_id, value, access_token=None, as_text=False):
     url = f"{SUPABASE_URL}/rest/v1/rpc/set_openmeteo"


### PR DESCRIPTION
## Summary
- aggregate OpenMeteo hourly responses into daypart averages covering wave height, swell period, and wind metrics before persisting to Supabase
- request additional hourly wind variables from OpenMeteo so the stored payload can populate all three GitHub Pages forecast features
- update the web client to normalise spot IDs, merge the aggregated metrics into SMS-derived data per daypart, and fall back to local aggregation when Supabase still returns hourly arrays

## Testing
- python -m compileall helper_functions.py openmeteo_api.py supabase_api.py main.py
- node --check react-app.js

------
https://chatgpt.com/codex/tasks/task_e_68cd1828272c83269153b149876f123c